### PR TITLE
Run with 2000 apc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -4086,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4113,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4172,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "syn 2.0.102",
 ]
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4542,7 +4542,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "getrandom 0.2.16",
  "libm",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4724,7 +4724,6 @@ dependencies = [
  "openvm-sdk",
  "openvm-stark-sdk",
  "openvm-transpiler",
- "powdr-constraint-solver",
  "powdr-number",
  "powdr-openvm",
  "powdr-riscv-elf",
@@ -4772,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4793,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4817,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -4826,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4842,7 +4841,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4895,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4906,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4929,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4938,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5016,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"
 dependencies = [
  "elf",
  "eyre",
@@ -5888,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "powdr-ast"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "auto_enums",
  "derive_more 0.99.20",
@@ -5904,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "powdr-autoprecompiles"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "itertools 0.13.0",
  "lazy_static",
@@ -5921,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "powdr-constraint-solver"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "auto_enums",
  "derive_more 0.99.20",
@@ -5934,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "powdr-expression"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "derive_more 0.99.20",
  "itertools 0.13.0",
@@ -5947,12 +5946,12 @@ dependencies = [
 [[package]]
 name = "powdr-isa-utils"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 
 [[package]]
 name = "powdr-number"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -5975,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "powdr-openvm"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "clap",
  "derive_more 2.0.1",
@@ -5983,13 +5982,16 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "openvm",
+ "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
+ "openvm-bigint-circuit",
  "openvm-bigint-transpiler",
  "openvm-build",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5997,6 +5999,8 @@ dependencies = [
  "openvm-keccak256-transpiler",
  "openvm-native-circuit",
  "openvm-native-recursion",
+ "openvm-pairing-circuit",
+ "openvm-pairing-transpiler",
  "openvm-rv32im-circuit",
  "openvm-rv32im-guest",
  "openvm-rv32im-transpiler",
@@ -6022,7 +6026,7 @@ dependencies = [
 [[package]]
 name = "powdr-parser"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "derive_more 0.99.20",
  "lalrpop 0.19.12",
@@ -6037,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "powdr-parser-util"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "codespan-reporting",
  "lalrpop-util 0.19.12",
@@ -6048,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "powdr-pil-analyzer"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "itertools 0.13.0",
  "lazy_static",
@@ -6062,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "powdr-pilopt"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "itertools 0.13.0",
  "log",
@@ -6076,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "powdr-riscv-elf"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "gimli",
  "goblin",
@@ -6092,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "powdr-riscv-types"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 dependencies = [
  "powdr-isa-utils",
 ]
@@ -6100,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "powdr-syscalls"
 version = "0.1.4"
-source = "git+https://github.com/powdr-labs/powdr.git?rev=c2ef9e4#c2ef9e4533106a1706deb5eb922d107959244130"
+source = "git+https://github.com/powdr-labs/powdr.git?rev=904c69f#904c69fb43825d67c21d30ba6b9df6a981f75127"
 
 [[package]]
 name = "powerfmt"
@@ -9438,4 +9442,4 @@ dependencies = [
 [[patch.unused]]
 name = "cargo-openvm"
 version = "1.2.0"
-source = "git+https://github.com/powdr-labs/openvm.git?rev=f12a2fc#f12a2fc2b44257e5df9c8f2e87031aaaf0ac1d42"
+source = "git+https://github.com/powdr-labs/openvm.git?rev=1dfd9ef#1dfd9efef40ecabb984f76493cd1f78becd5ce53"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,10 +150,9 @@ openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", tag
 openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
 
 # powdr
-powdr-openvm = { git = "https://github.com/powdr-labs/powdr.git", rev = "c2ef9e4", default-features = false }
-powdr-riscv-elf = { git = "https://github.com/powdr-labs/powdr.git", rev = "c2ef9e4", default-features = false }
-powdr-number = { git = "https://github.com/powdr-labs/powdr.git", rev = "c2ef9e4", default-features = false }
-powdr-constraint-solver = { git = "https://github.com/powdr-labs/powdr.git", rev = "c2ef9e4", default-features = false }
+powdr-openvm = { git = "https://github.com/powdr-labs/powdr.git", rev = "904c69f", default-features = false }
+powdr-riscv-elf = { git = "https://github.com/powdr-labs/powdr.git", rev = "904c69f", default-features = false }
+powdr-number = { git = "https://github.com/powdr-labs/powdr.git", rev = "904c69f", default-features = false }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"
@@ -195,54 +194,54 @@ openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", re
 # Comment it out if you want to use a local OpenVM instead (patches below this block).
 # This rev needs to be the same that powdr uses.
 [patch."https://github.com/openvm-org/openvm.git"]
-openvm-benchmarks-prove = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
+openvm-benchmarks-prove = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
 # OpenVM
-openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-cargo-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-mod-circuit-builder = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-poseidon2-air = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-build = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-macros-common = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
+openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+cargo-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-mod-circuit-builder = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-poseidon2-air = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-build = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-macros-common = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
 
 # Extensions
-openvm-algebra-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-algebra-moduli-macros = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-algebra-complex-macros = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-bigint-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-bigint-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-ecc-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-ecc-sw-macros = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-keccak256-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-sha256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-sha256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-sha256-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-native-compiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-native-compiler-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-pairing-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-pairing-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-pairing-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-rv32-adapters = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
-openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "f12a2fc" }
+openvm-algebra-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-algebra-moduli-macros = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-algebra-complex-macros = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-bigint-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-bigint-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-ecc-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-ecc-sw-macros = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-keccak256-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-sha256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-sha256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-sha256-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-native-compiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-native-compiler-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-pairing-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-pairing-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-pairing-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-rv32-adapters = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
+openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "1dfd9ef" }
 
 # LOCAL USAGE PATCHES
 

--- a/crates/host-bench/Cargo.toml
+++ b/crates/host-bench/Cargo.toml
@@ -56,7 +56,6 @@ halo2-axiom = { version = "0.5.0", default-features = false }
 powdr-openvm = { workspace = true }
 powdr-riscv-elf = { workspace = true }
 powdr-number = { workspace = true }
-powdr-constraint-solver = { workspace = true }
 
 [features]
 default = ["mimalloc", "bench-metrics"]

--- a/crates/host-bench/src/lib.rs
+++ b/crates/host-bench/src/lib.rs
@@ -498,10 +498,7 @@ mod powdr {
 
         let powdr_config = PowdrConfig::new(apc as u64, apc_skip as u64)
             .with_bus_map(bus_map)
-            .with_degree_bound(powdr_constraint_solver::inliner::DegreeBound {
-                identities: 2,
-                bus_interactions: 2,
-            });
+            .with_degree_bound(powdr_openvm::DegreeBound { identities: 2, bus_interactions: 2 });
 
         let elf_powdr = load_elf_from_buffer(elf);
 
@@ -518,7 +515,7 @@ mod powdr {
             exe,
             vm_config.clone(),
             &elf_powdr.text_labels,
-            &airs,
+            airs,
             powdr_config.clone(),
             // TODO: We use PGO in Instuction mode since Cell mode requires creating all APCs, which runs out of memory.
             PgoConfig::Instruction(pgo_data),


### PR DESCRIPTION
```
MODE="prove-app" APC=2000 APC_SKIP=0 /usr/bin/time -v ./run.sh
```

On this branch:
```
Command being timed: "./run.sh"
        User time (seconds): 9104.08
        System time (seconds): 360.57
        Percent of CPU this job got: 1294%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 12:11.13
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 170390408
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 27328911
        Voluntary context switches: 5543241
        Involuntary context switches: 2434456
        Swaps: 0
        File system inputs: 7832
        File system outputs: 130488
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

On [the previous commit](https://github.com/powdr-labs/openvm-reth-benchmark/pull/1):
```
./run.sh: line 37: 3546499 Killed                  RUST_LOG="debug" OUTPUT_PATH="metrics.json" ./target/$PROFILE/openvm-reth-benchmark-bin --kzg-params-dir $PARAMS_DIR --mode $MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache --apc "$APC" --apc-skip "$APC_SKIP"
Command exited with non-zero status 137
        Command being timed: "./run.sh"
        User time (seconds): 1266.95
        System time (seconds): 71.27
        Percent of CPU this job got: 245%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 9:05.44
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 218005860
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 4337
        Minor (reclaiming a frame) page faults: 8815863
        Voluntary context switches: 2856188
        Involuntary context switches: 29996
        Swaps: 0
        File system inputs: 1591728
        File system outputs: 610800
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 137
```